### PR TITLE
Implement metrics collection for specific to the Blob Storage Stream

### DIFF
--- a/src/Contracts/DeclaredMetrics.cs
+++ b/src/Contracts/DeclaredMetrics.cs
@@ -7,13 +7,13 @@ public class DeclaredMetrics
 {
     /// <summary>Number of objects found by streamer in the source bucket.</summary>
     public const string OBJECTS_INCOMING = "objects.incoming";
-    
+
     /// <summary>Number of objects written by streamer into the target bucket.</summary>
     public const string OBJECTS_OUTGOING = "objects.outgoing";
-    
+
     /// <summary>Number objects size processed by the streamer.</summary>
     public const string OBJECTS_SIZE = "objects.size";
-    
+
     /// <summary>Number of objects deleted by the streamer in the source bucket.</summary>
     public const string OBJECTS_DELETED = "objects.deleted";
 }

--- a/src/Contracts/DeclaredMetrics.cs
+++ b/src/Contracts/DeclaredMetrics.cs
@@ -1,0 +1,19 @@
+﻿namespace Arcane.Stream.BlobStorage.Contracts;
+
+/// <summary>
+/// Metrics specific to the BlobStorage stream plugin.
+/// </summary>
+public class DeclaredMetrics
+{
+    /// <summary>Number of objects found by streamer in the source bucket.</summary>
+    public const string OBJECTS_INCOMING = "objects.incoming";
+    
+    /// <summary>Number of objects written by streamer into the target bucket.</summary>
+    public const string OBJECTS_OUTGOING = "objects.outgoing";
+    
+    /// <summary>Number objects size processed by the streamer.</summary>
+    public const string OBJECTS_SIZE = "objects.size";
+    
+    /// <summary>Number of objects deleted by the streamer in the source bucket.</summary>
+    public const string OBJECTS_DELETED = "objects.size";
+}

--- a/src/Contracts/DeclaredMetrics.cs
+++ b/src/Contracts/DeclaredMetrics.cs
@@ -15,5 +15,5 @@ public class DeclaredMetrics
     public const string OBJECTS_SIZE = "objects.size";
     
     /// <summary>Number of objects deleted by the streamer in the source bucket.</summary>
-    public const string OBJECTS_DELETED = "objects.size";
+    public const string OBJECTS_DELETED = "objects.deleted";
 }

--- a/src/Exceptions/ConfigurationException.cs
+++ b/src/Exceptions/ConfigurationException.cs
@@ -5,10 +5,10 @@ namespace Arcane.Stream.BlobStorage.Exceptions;
 /// <summary>
 /// Thrown if invalid configuration is provided
 /// </summary>
-public class ConfigurationException: Exception
+public class ConfigurationException : Exception
 {
-    public ConfigurationException(string message): base(message)
+    public ConfigurationException(string message) : base(message)
     {
-        
+
     }
 }

--- a/src/Exceptions/SinkException.cs
+++ b/src/Exceptions/SinkException.cs
@@ -7,7 +7,7 @@ namespace Arcane.Stream.BlobStorage.Exceptions;
 /// </summary>
 public class SinkException : Exception
 {
-    public SinkException(string message): base(message)
+    public SinkException(string message) : base(message)
     {
     }
 }

--- a/src/Extensions/AmazonS3StoragepathExtensions.cs
+++ b/src/Extensions/AmazonS3StoragepathExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using Snd.Sdk.Storage.Models.BlobPath;
+
+namespace Arcane.Stream.BlobStorage.Extensions;
+
+public static class AmazonS3StoragePathExtensions
+{
+    /// <summary>
+    /// Converts the Amazon S3 storage path to a dictionary of metrics tags
+    /// </summary>
+    /// <param name="path">Path</param>
+    /// <returns>Metrics tags</returns>
+   public static SortedDictionary<string, string> ToMetricsTags(this AmazonS3StoragePath path)
+   {
+       return new SortedDictionary<string, string>
+       {
+           { "bucket", path.Bucket },
+           { "key", path.ObjectKey }
+       };
+   }
+}

--- a/src/Extensions/AmazonS3StoragepathExtensions.cs
+++ b/src/Extensions/AmazonS3StoragepathExtensions.cs
@@ -18,7 +18,7 @@ public static class AmazonS3StoragePathExtensions
         return new SortedDictionary<string, string>
         {
             { "blob-storage.arcane.sneaksanddata.com/bucket", path.Bucket },
-            { "blob-storage.arcane.sneaksanddata.com/key", path.ObjectKey },
+            { "blob-storage.arcane.sneaksanddata.com/prefix", path.ObjectKey },
             { "arcane.sneaksanddata.com/kind", CodeExtensions.CamelCaseToSnakeCase(context.StreamKind) },
             { "arcane.sneaksanddata.com/stream_id", context.StreamId }
         };

--- a/src/Extensions/AmazonS3StoragepathExtensions.cs
+++ b/src/Extensions/AmazonS3StoragepathExtensions.cs
@@ -17,8 +17,8 @@ public static class AmazonS3StoragePathExtensions
     {
         return new SortedDictionary<string, string>
         {
-            { "bucket", path.Bucket },
-            { "key", path.ObjectKey },
+            { "blob-storage.arcane.sneaksanddata.com/bucket", path.Bucket },
+            { "blob-storage.arcane.sneaksanddata.com/key", path.ObjectKey },
             { "arcane.sneaksanddata.com/kind", CodeExtensions.CamelCaseToSnakeCase(context.StreamKind) },
             { "arcane.sneaksanddata.com/stream_id", context.StreamId }
         };

--- a/src/Extensions/AmazonS3StoragepathExtensions.cs
+++ b/src/Extensions/AmazonS3StoragepathExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using Arcane.Framework.Services.Base;
+using Snd.Sdk.Helpers;
 using Snd.Sdk.Storage.Models.BlobPath;
 
 namespace Arcane.Stream.BlobStorage.Extensions;
@@ -6,16 +8,19 @@ namespace Arcane.Stream.BlobStorage.Extensions;
 public static class AmazonS3StoragePathExtensions
 {
     /// <summary>
-    /// Converts the Amazon S3 storage path to a dictionary of metrics tags
+    /// Converts the Amazon S3 storage path to a dictionary of metrics tags.
     /// </summary>
-    /// <param name="path">Path</param>
-    /// <returns>Metrics tags</returns>
-   public static SortedDictionary<string, string> ToMetricsTags(this AmazonS3StoragePath path)
-   {
-       return new SortedDictionary<string, string>
-       {
-           { "bucket", path.Bucket },
-           { "key", path.ObjectKey }
-       };
-   }
+    /// <param name="path">Path in Snd.Sdk format.</param>
+    /// <param name="context">Stream context.</param>
+    /// <returns>Metrics tags as sorted dictionary.</returns>
+    public static SortedDictionary<string, string> ToMetricsTags(this AmazonS3StoragePath path, IStreamContext context)
+    {
+        return new SortedDictionary<string, string>
+        {
+            { "bucket", path.Bucket },
+            { "key", path.ObjectKey },
+            { "arcane.sneaksanddata.com/kind", CodeExtensions.CamelCaseToSnakeCase(context.StreamKind) },
+            { "arcane.sneaksanddata.com/stream_id", context.StreamId }
+        };
+    }
 }

--- a/src/Extensions/StreamContextExtensions.cs
+++ b/src/Extensions/StreamContextExtensions.cs
@@ -8,7 +8,7 @@ namespace Arcane.Stream.BlobStorage.Extensions;
 
 public static class StreamContextExtensions
 {
-    public static Sink<(IStoragePath, string), Task> GetSink(this BlobStorageStreamContext context, Func<(IStoragePath, string), Task > action)
+    public static Sink<(IStoragePath, string), Task> GetSink(this BlobStorageStreamContext context, Func<(IStoragePath, string), Task> action)
     {
         return Sink.ForEachAsync<(IStoragePath, string)>(context.DeleteParallelism, async deleteRequest =>
         {

--- a/src/GraphBuilder/BlobStorageGraphBuilder.cs
+++ b/src/GraphBuilder/BlobStorageGraphBuilder.cs
@@ -28,7 +28,7 @@ public class BlobStorageGraphBuilder : IStreamGraphBuilder<BlobStorageStreamCont
     private readonly IBlobStorageReader sourceBlobStorageReader;
     private readonly ILogger<BlobStorageGraphBuilder> logger;
     private readonly MetricsService metricsService;
-    
+
     private SortedDictionary<string, string> sourceDimensions;
     private SortedDictionary<string, string> targetDimensions;
 
@@ -47,7 +47,7 @@ public class BlobStorageGraphBuilder : IStreamGraphBuilder<BlobStorageStreamCont
         this.logger = logger;
         this.metricsService = metricsService;
     }
-    
+
     public IRunnableGraph<(UniqueKillSwitch, Task)> BuildGraph(BlobStorageStreamContext context)
     {
         if (!AmazonS3StoragePath.IsAmazonS3Path(context.SourcePath))
@@ -59,7 +59,7 @@ public class BlobStorageGraphBuilder : IStreamGraphBuilder<BlobStorageStreamCont
         {
             throw new ConfigurationException("Target path is invalid, only Amazon S3 paths are supported");
         }
-        
+
         if (context.IsBackfilling)
         {
             throw new ConfigurationException("Backfilling is not supported for this stream type");
@@ -67,15 +67,15 @@ public class BlobStorageGraphBuilder : IStreamGraphBuilder<BlobStorageStreamCont
 
         var parsedSourcePath = new AmazonS3StoragePath(context.SourcePath);
         this.sourceDimensions = parsedSourcePath.ToMetricsTags(context);
-        
+
         var parsedTargetPath = new AmazonS3StoragePath(context.TargetPath);
-        this.targetDimensions= parsedTargetPath.ToMetricsTags(context);
-        
+        this.targetDimensions = parsedTargetPath.ToMetricsTags(context);
+
         var source = BlobStorageSource.Create(
             context.SourcePath,
             this.sourceBlobListStorageService,
             context.ChangeCaptureInterval);
-        
+
         return Source.FromGraph(source)
             .Throttle(context.ElementsPerSecond, TimeSpan.FromSeconds(1), context.RequestThrottleBurst, ThrottleMode.Shaping)
             .Select(document =>
@@ -127,7 +127,7 @@ public class BlobStorageGraphBuilder : IStreamGraphBuilder<BlobStorageStreamCont
             throw new SinkException($"Failed to remove blob {sourceBlobName} from {sourceRoot}");
         }
     }
-    
+
     private static Directive DecideOnFailure(Exception ex)
     {
         return ex switch

--- a/src/GraphBuilder/BlobStorageGraphBuilder.cs
+++ b/src/GraphBuilder/BlobStorageGraphBuilder.cs
@@ -1,15 +1,18 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Akka.Streams;
 using Akka.Streams.Dsl;
 using Akka.Streams.Supervision;
 using Arcane.Framework.Services.Base;
 using Arcane.Framework.Sources.BlobStorage;
+using Arcane.Stream.BlobStorage.Contracts;
 using Arcane.Stream.BlobStorage.Exceptions;
 using Arcane.Stream.BlobStorage.Extensions;
 using Arcane.Stream.BlobStorage.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Snd.Sdk.Metrics.Base;
 using Snd.Sdk.Storage.Base;
 using Snd.Sdk.Storage.Models.Base;
 using Snd.Sdk.Storage.Models.BlobPath;
@@ -24,12 +27,17 @@ public class BlobStorageGraphBuilder : IStreamGraphBuilder<BlobStorageStreamCont
     private readonly IBlobStorageWriter sourceBlobStorageWriter;
     private readonly IBlobStorageReader sourceBlobStorageReader;
     private readonly ILogger<BlobStorageGraphBuilder> logger;
+    private readonly MetricsService metricsService;
+    
+    private SortedDictionary<string, string> sourceDimensions;
+    private SortedDictionary<string, string> targetDimensions;
 
     public BlobStorageGraphBuilder(
         IBlobStorageListService sourceBlobStorageService,
         IBlobStorageReader sourceBlobStorageReader,
         [FromKeyedServices(StorageType.SOURCE)] IBlobStorageWriter sourceBlobStorageWriter,
         [FromKeyedServices(StorageType.TARGET)] IBlobStorageWriter targetBlobStorageService,
+        MetricsService metricsService,
         ILogger<BlobStorageGraphBuilder> logger)
     {
         this.sourceBlobListStorageService = sourceBlobStorageService;
@@ -37,6 +45,7 @@ public class BlobStorageGraphBuilder : IStreamGraphBuilder<BlobStorageStreamCont
         this.sourceBlobStorageWriter = sourceBlobStorageWriter;
         this.targetBlobStorageService = targetBlobStorageService;
         this.logger = logger;
+        this.metricsService = metricsService;
     }
     
     public IRunnableGraph<(UniqueKillSwitch, Task)> BuildGraph(BlobStorageStreamContext context)
@@ -50,17 +59,30 @@ public class BlobStorageGraphBuilder : IStreamGraphBuilder<BlobStorageStreamCont
         {
             throw new ConfigurationException("Target path is invalid, only Amazon S3 paths are supported");
         }
+        
+        if (context.IsBackfilling)
+        {
+            throw new ConfigurationException("Backfilling is not supported for this stream type");
+        }
 
         var parsedSourcePath = new AmazonS3StoragePath(context.SourcePath);
+        this.sourceDimensions = parsedSourcePath.ToMetricsTags();
+        
         var parsedTargetPath = new AmazonS3StoragePath(context.TargetPath);
+        this.targetDimensions= parsedTargetPath.ToMetricsTags();
+        
         var source = BlobStorageSource.Create(
             context.SourcePath,
             this.sourceBlobListStorageService,
             context.ChangeCaptureInterval);
         
         return Source.FromGraph(source)
-            .Throttle(context.ElementsPerSecond, TimeSpan.FromSeconds(1), context.RequestThrottleBurst,
-                ThrottleMode.Shaping)
+            .Throttle(context.ElementsPerSecond, TimeSpan.FromSeconds(1), context.RequestThrottleBurst, ThrottleMode.Shaping)
+            .Select(document =>
+            {
+                this.metricsService.Increment(DeclaredMetrics.OBJECTS_INCOMING, this.sourceDimensions);
+                return document;
+            })
             .SelectAsync(context.ReadParallelism, b => this.GetBlobContentAsync(parsedSourcePath, b))
             .SelectAsync(context.WriteParallelism, b => this.SaveBlobContentAsync(parsedTargetPath, b))
             .ViaMaterialized(KillSwitches.Single<(IStoragePath, string)>(), Keep.Right)
@@ -70,7 +92,7 @@ public class BlobStorageGraphBuilder : IStreamGraphBuilder<BlobStorageStreamCont
 
     private Task<(IStoragePath, string, BinaryData)> GetBlobContentAsync(IStoragePath rootPath, string blobPath)
     {
-        this.logger.LogInformation("Reading blob content from {BlobPath}", rootPath.Join(blobPath).ToHdfsPath());
+        this.logger.LogDebug("Reading blob content from {BlobPath}", rootPath.Join(blobPath).ToHdfsPath());
         return this.sourceBlobStorageReader
             .GetBlobContentAsync(rootPath.ToHdfsPath(), blobPath, data => data)
             .Map(data =>
@@ -79,7 +101,7 @@ public class BlobStorageGraphBuilder : IStreamGraphBuilder<BlobStorageStreamCont
                 {
                     throw new ProcessingException(rootPath, blobPath);
                 }
-
+                this.metricsService.Count(DeclaredMetrics.OBJECTS_SIZE, data.ToMemory().Length, this.sourceDimensions);
                 return (rootPath, blobPath, data);
             });
     }
@@ -87,7 +109,8 @@ public class BlobStorageGraphBuilder : IStreamGraphBuilder<BlobStorageStreamCont
     private Task<(IStoragePath, string)> SaveBlobContentAsync(IStoragePath targetPath, (IStoragePath, string, BinaryData) writeRequest)
     {
         var (rootPath, blobName, data) = writeRequest;
-        this.logger.LogInformation("Saving blob content to {BlobPath}", targetPath.Join(blobName).ToHdfsPath());
+        this.logger.LogDebug("Saving blob content to {BlobPath}", targetPath.Join(blobName).ToHdfsPath());
+        this.metricsService.Increment(DeclaredMetrics.OBJECTS_OUTGOING, this.targetDimensions);
         return this.targetBlobStorageService
             .SaveBytesAsBlob(data, targetPath.ToHdfsPath(), blobName, overwrite: true)
             .Map(_ => (rootPath, blobName));
@@ -96,9 +119,10 @@ public class BlobStorageGraphBuilder : IStreamGraphBuilder<BlobStorageStreamCont
     private async Task RemoveSource((IStoragePath, string) deleteRequest)
     {
         var (sourceRoot, sourceBlobName) = deleteRequest;
-        this.logger.LogInformation("Removing blob content from {BlobPath}", sourceRoot.Join(sourceBlobName).ToHdfsPath());
-        var res = await this.sourceBlobStorageWriter.RemoveBlob(sourceRoot.ToHdfsPath(), sourceBlobName);
-        if (!res)
+        this.logger.LogDebug("Removing blob content from {BlobPath}", sourceRoot.Join(sourceBlobName).ToHdfsPath());
+        this.metricsService.Increment(DeclaredMetrics.OBJECTS_DELETED, this.sourceDimensions);
+        var success = await this.sourceBlobStorageWriter.RemoveBlob(sourceRoot.ToHdfsPath(), sourceBlobName);
+        if (!success)
         {
             throw new SinkException($"Failed to remove blob {sourceBlobName} from {sourceRoot}");
         }

--- a/src/GraphBuilder/BlobStorageGraphBuilder.cs
+++ b/src/GraphBuilder/BlobStorageGraphBuilder.cs
@@ -66,10 +66,10 @@ public class BlobStorageGraphBuilder : IStreamGraphBuilder<BlobStorageStreamCont
         }
 
         var parsedSourcePath = new AmazonS3StoragePath(context.SourcePath);
-        this.sourceDimensions = parsedSourcePath.ToMetricsTags();
+        this.sourceDimensions = parsedSourcePath.ToMetricsTags(context);
         
         var parsedTargetPath = new AmazonS3StoragePath(context.TargetPath);
-        this.targetDimensions= parsedTargetPath.ToMetricsTags();
+        this.targetDimensions= parsedTargetPath.ToMetricsTags(context);
         
         var source = BlobStorageSource.Create(
             context.SourcePath,

--- a/src/Models/BlobStorageStreamContext.cs
+++ b/src/Models/BlobStorageStreamContext.cs
@@ -13,34 +13,34 @@ public class BlobStorageStreamContext : IStreamContext, IStreamContextWriter
     /// Source blob path. Should be in Proteus format.
     /// </summary>
     public string SourcePath { get; init; }
-    
+
     /// <summary>
     /// Target blob path. Should be in Proteus format.
     /// </summary>
     public string TargetPath { get; init; }
-    
+
     /// <summary>
     /// Parallelism for read operations (include listing blobs).
     /// </summary>
     public int ReadParallelism { get; init; }
-    
+
     /// <summary>
     /// Parallelism for write operations.
     /// </summary>
     public int WriteParallelism { get; init; }
-    
+
     /// <summary>
     /// Parallelism for delete operations.
     /// </summary>
     public int DeleteParallelism { get; init; }
-    
+
     /// <summary>
     /// How often to check for changes in the source blob storage.
     /// </summary>
     [JsonConverter(typeof(SecondsToTimeSpanConverter))]
     [JsonPropertyName("changeCaptureIntervalSeconds")]
     public TimeSpan ChangeCaptureInterval { get; init; }
-    
+
     /// <summary>
     /// Maximum allowed burst before throttling kicks in.
     /// </summary>

--- a/test/BlobStorageStreamTests.cs
+++ b/test/BlobStorageStreamTests.cs
@@ -36,9 +36,10 @@ public class BlobStorageStreamTests
             TargetPath = "s3a://target-bucket/target/",
             ChangeCaptureInterval = TimeSpan.FromSeconds(1),
             ElementsPerSecond = 1000,
-            RequestThrottleBurst = 100
+            RequestThrottleBurst = 100,
         };
 
+        context.SetStreamKind(nameof(this.TestCanStreamBlobs));
         this.blobStorageServiceMock.Setup(s
             => s.RemoveBlob(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(true);
@@ -88,6 +89,7 @@ public class BlobStorageStreamTests
             RequestThrottleBurst = 100
         };
 
+        context.SetStreamKind(nameof(this.TestFailsIfCannotDeleteBlob));
         var graph = builder.BuildGraph(context);
         var callCount = 0;
 

--- a/test/BlobStorageStreamTests.cs
+++ b/test/BlobStorageStreamTests.cs
@@ -39,7 +39,7 @@ public class BlobStorageStreamTests
             RequestThrottleBurst = 100
         };
 
-        this.blobStorageServiceMock.Setup(s 
+        this.blobStorageServiceMock.Setup(s
             => s.RemoveBlob(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(true);
         var graph = builder.BuildGraph(context);
@@ -66,12 +66,12 @@ public class BlobStorageStreamTests
         await task;
 
         this.blobStorageServiceMock.Verify(s =>
-            s.SaveBytesAsBlob(It.IsAny<BinaryData>(),"s3a://target-bucket/target", "name", true));
+            s.SaveBytesAsBlob(It.IsAny<BinaryData>(), "s3a://target-bucket/target", "name", true));
         this.blobStorageServiceMock.Verify(s => s.ListBlobsAsEnumerable("s3a://source-bucket/prefix/to/blobs"));
         this.blobStorageServiceMock.Verify(s
             => s.RemoveBlob("s3a://source-bucket/prefix/to/blobs", "name"));
     }
-    
+
     [Fact]
     public async Task TestFailsIfCannotDeleteBlob()
     {
@@ -104,8 +104,8 @@ public class BlobStorageStreamTests
                 callCount++;
             })
             .Returns(new[] { new StoredBlob { Name = "name" } });
-        
-        await Assert.ThrowsAnyAsync<AggregateException>( async () => await task);
+
+        await Assert.ThrowsAnyAsync<AggregateException>(async () => await task);
     }
 
 

--- a/test/BlobStorageStreamTests.cs
+++ b/test/BlobStorageStreamTests.cs
@@ -8,6 +8,7 @@ using Arcane.Stream.BlobStorage.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Snd.Sdk.Metrics.Base;
 using Snd.Sdk.Storage.Base;
 using Snd.Sdk.Storage.Models;
 using Xunit;
@@ -118,6 +119,7 @@ public class BlobStorageStreamTests
             .AddKeyedSingleton<IBlobStorageWriter>(StorageType.SOURCE, this.blobStorageServiceMock.Object)
             .AddKeyedSingleton<IBlobStorageWriter>(StorageType.TARGET, this.blobStorageServiceMock.Object)
             .AddSingleton(new Mock<ILogger<BlobStorageGraphBuilder>>().Object)
+            .AddSingleton(new Mock<MetricsService>().Object)
             .AddSingleton<BlobStorageGraphBuilder>()
             .BuildServiceProvider();
     }


### PR DESCRIPTION
Resolves #27

## Scope

Implemented custom metrics for Blob Storage stream. This stream is designed to mirror data from an S3 bucket to MinIO storage delete objects from source bucket when objects are replicated. This stream does not fit to "standard" metrics model used in other streams, so we implement the custom metrics for this data steaming plugin.

Custom stream metrics list:
- `objects.incoming`: Number of objects found in the source bucket.
- `objects.outgoing`: Number of objects written to the target bucket.
- `objects.size`: Size of each object going through the stream in bytes.
- `objects.deleted`: Number of objects deleted from the source bucket.

Custom metrics tags:
- `blob-storage.arcane.sneaksanddata.com/bucket`: Bucket name (both for source and target).
- `blob-storage.arcane.sneaksanddata.com/prefix`: Object key prefix  (both for source and target).

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.